### PR TITLE
Remove format limitation

### DIFF
--- a/audio2numpy/loader.py
+++ b/audio2numpy/loader.py
@@ -43,13 +43,11 @@ def _audio_read(path):
             return RawAudioFile(path)
         except DecodeError:
             pass
-    elif path.endswith(".mp3"):
+    else:
         try:
             return FFmpegAudioFile(path)
         except DecodeError:
             pass
-    else:
-        raise AudioFormatError("Only support mp3, wav, aiff formats.")
     msg = """It is likely that ffmpeg is not yet installed. Please refer github repo for instruction. 
     MacOS: brew install ffmpeg.
     Linux: sudo apt-get install ffmpeg


### PR DESCRIPTION
There is no point in limiting the allowed file-extensions to `.mp3` since ffmpeg can handle a lot of formats. This fixes issue #1 
You could additionally also rename `mp3dec.py` to something like `ffmpegdec.py` since it's not limited to decoding mp3 files.

I verified this with `.m4a`,  `.ogg` and a few others.